### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  actions: write
 name: Android CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/rena311706015/MovieDiscover/security/code-scanning/1](https://github.com/rena311706015/MovieDiscover/security/code-scanning/1)

To fix this issue, we will explicitly add a `permissions` block at the root of the workflow file. Since the workflow performs tasks such as checking out code, running tests, and uploading artifacts, it requires read access to repository contents and the ability to upload artifacts. The least-privilege permissions required for these tasks are `contents: read` and `actions: write`. We will place the `permissions` block immediately after the `name` field in the workflow file to apply it to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
